### PR TITLE
ci: Add PDF-diff commenting to PR workflow

### DIFF
--- a/.github/workflows/kibot_diff.yml
+++ b/.github/workflows/kibot_diff.yml
@@ -1,0 +1,64 @@
+name: Run PDF-diff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  run-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # So we can run a diff between changes
+          fetch-depth: '0'
+
+      - name: Run KiBot
+        uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          config: kicad/diff.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: output
+          # optional - schematic file
+          schema: 'kicad/bms-c1.kicad_sch'
+          # optional - PCB design file
+          board: 'kicad/bms-c1.kicad_pcb'
+
+      - name: Upload pcb
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step-pcb
+        with:
+          name: bms-c1-diff_pcb.pdf.pdf
+          path: output/diff/bms-c1-diff_pcb.pdf
+
+      - name: Upload schematic
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step-sch
+        with:
+          name: bms-c1-diff_sch.pdf
+          path: output/diff/bms-c1-diff_sch.pdf
+
+      - name: Prepare variables for comment body
+        id: comment-body
+        run: |
+          echo "base_short=$(git rev-parse --short ${{ github.event.pull_request.base.sha }})" >> "$GITHUB_OUTPUT"
+          echo "head_short=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> "$GITHUB_OUTPUT"
+
+      - name: 'Prepare artifact for transfer'
+        run: |
+          # Save ENV for transfer
+          echo "PR_BASE_SHORT=${{ steps.comment-body.outputs.base_short }}" >> pr.env
+          echo "PR_HEAD_SHORT=${{ steps.comment-body.outputs.head_short }}" >> pr.env
+          echo "PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> pr.env
+          echo "PR_HEAD_REF=${{ github.event.pull_request.head.ref }}" >> pr.env
+          echo "PR_LINK_SCH=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step-sch.outputs.artifact-id }}" >> pr.env
+          echo "PR_LINK_PCB=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step-pcb.outputs.artifact-id }}" >> pr.env
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
+
+      - name: 'Upload artifact for workflow transfer'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr.env
+          retention-days: 1

--- a/.github/workflows/kibot_run_comment.yml
+++ b/.github/workflows/kibot_run_comment.yml
@@ -1,0 +1,46 @@
+# This file, 'kibot_run_comment.yml', along with 'kibot_diff.yml', forms a two-stage GitHub Actions workflow for secure KiCad diffs management.
+# 'kibot_diff.yml' executes the KiBot diff process, while this file handles safe posting of results to pull requests.
+# This method follows the security guidelines from the GitHub Security Lab (https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
+# and addresses the 'Resource not accessible by integration' issue in workflows triggered by forks.
+
+name: Comment with PDF-diff
+
+on:
+  workflow_run:
+    workflows: ["Run PDF-diff"]
+    types:
+      - completed
+
+jobs:
+  comment-diff:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: 'Restore preserved ENV'
+        run: cat pr.env >> "${GITHUB_ENV}"
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: 'github-actions[bot]'
+          body-regex: 'Diff between .* \(\S+\) and .* \(\S+\):'
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ env.PR_NUMBER }}
+          body: |
+            Diff between ${{ env.PR_BASE_REF }} (${{ env.PR_BASE_SHORT }}) and ${{ env.PR_HEAD_REF }} (${{ env.PR_HEAD_SHORT }}):
+            - [bms-c1-diff_sch.pdf](${{ env.PR_LINK_SCH }})
+            - [bms-c1-diff_pcb.pdf](${{ env.PR_LINK_PCB }})
+          edit-mode: replace

--- a/kicad/diff.kibot.yaml
+++ b/kicad/diff.kibot.yaml
@@ -1,0 +1,29 @@
+kibot:
+  version: 1
+
+outputs:
+- name: basic_diff_pcb
+  comment: PCB diff between the last two changes
+  type: diff
+  dir: diff
+  layers: all
+  options:
+    old: main
+    old_type: git
+    new: HEAD
+    new_type: git
+    add_link_id: true
+    pcb: true
+    only_different: true
+- name: basic_diff_sch
+  comment: Schematic diff between the last two changes
+  type: diff
+  dir: diff
+  options:
+    old: main
+    old_type: git
+    new: HEAD
+    new_type: git
+    add_link_id: true
+    pcb: false
+    only_different: true


### PR DESCRIPTION
This PR is a followup of https://github.com/LibreSolar/bms-c1/pull/48 to implement the task "Running diff tools on PR commits":
- Activates on pull request actions including opened, synchronized, reopened, and edited events.
- Includes a checkout step with full fetch depth to enable comprehensive diffs.
- Dynamically updates the KiBot configuration to reference the correct base branch of the pull request.
- Utilizes KiBot action for generating PCB and schematic differences, specifying configuration, output directory, and file paths.
- Uploads the resultant PCB and schematic PDFs as artifacts, using distinct names for easy identification.
- Employs 'find-comment' action to search for an existing comment made by github-actions[bot] and matches a specific regex pattern.
- Prepares short SHA values of base and head commits for comment inclusion.
- Creates or updates a PR comment with links to the diff PDFs, providing clear and accessible diff comparisons directly in the PR.

#### Limitations
The drawback of this method is that you need to be logged in to download the diffs.