### PR TITLE
ci: update kibot path pattern in workflow

### DIFF
--- a/.github/workflows/kibot_checks.yml
+++ b/.github/workflows/kibot_checks.yml
@@ -3,15 +3,15 @@ name: Run KiBot Checks
 on:
   push:
     paths:
-      - '*.kicad_sch'
-      - '*.kicad_pcb'
+      - '**.kicad_sch'
+      - '**.kicad_pcb'
       - '.github/workflows/kibot_checks.yml'
     branches-ignore:
       - gh-pages
   pull_request:
     paths:
-      - '*.kicad_sch'
-      - '*.kicad_pcb'
+      - '**.kicad_sch'
+      - '**.kicad_pcb'
       - '.github/workflows/kibot_checks.yml'
     branches-ignore:
       - gh-pages


### PR DESCRIPTION
Changed the path pattern in the workflow file to be the same as the one recommended in the [GitHub documentation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-including-paths). This makes sure the workflows run correctly and as expected.