### PR TITLE
ci: pin gh action to v2_k7_1_6_3 to resolve build errors

### DIFF
--- a/.github/workflows/kibot_diff.yml
+++ b/.github/workflows/kibot_diff.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Run KiBot
-        uses: INTI-CMNB/KiBot@v2_k7
+        uses: INTI-CMNB/KiBot@v2_k7_1_6_3
         with:
           config: kicad/diff.kibot.yaml
           # optional - prefix to output defined in config


### PR DESCRIPTION
Fixed a build error by specifying the version of a GitHub Action to `v2_k7_1_6_3`. This addresses an issue where the command `git worktree add --detach --force /tmp/tmpy_4q2jth main` failed. The error was resolved by using `v2_k7_1_6_3` until the changes in commit https://github.com/INTI-CMNB/KiBot/commit/d66188014c67307d9820ad9a72239d624488c446 are included in the LTS tag `v2_k7`. Following the resolution of issue https://github.com/INTI-CMNB/KiBot/issues/589, it will then be necessary to change `main` to `origin/main` in `diff.kibot.yaml`.